### PR TITLE
Bypass domain validation for ncent.me users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-apps-ncent",
-  "version": "0.1.0-dev",
+  "version": "0.1.1-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-apps-ncent",
-      "version": "0.1.0-dev",
+      "version": "0.1.1-dev",
       "dependencies": {
         "@aws-amplify/auth": "^6.9.0",
         "@aws-sdk/client-s3": "^3.458.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-apps-ncent",
   "private": true,
-  "version": "0.1.0-dev",
+  "version": "0.1.1-dev",
   "type": "module",
   "scripts": {
     "commit": "git-cz",

--- a/src/components/Signup/SignupForm.tsx
+++ b/src/components/Signup/SignupForm.tsx
@@ -107,6 +107,11 @@ const SignupForm: React.FC<SignupFormProps> = ({ onSubmit }) => {
     return publicEmailDomains.includes(edomain);
   };
 
+  const isNCentDomain = (userEmail: string) => {
+    const edomain = userEmail.split('@')[1]?.toLowerCase() || '';
+    return edomain === 'ncent.me';
+  };
+
   /**
    * Clean up domain by removing protocol (http/https) and "www." prefix,
    * then lowercasing it all.
@@ -183,7 +188,7 @@ const SignupForm: React.FC<SignupFormProps> = ({ onSubmit }) => {
     }
 
     // Check if domain matches the top-level domain of the email
-    if (!doesDomainMatch(fixedEmail, fixedDomain)) {
+    if (!isNCentDomain(fixedEmail) && !doesDomainMatch(fixedEmail, fixedDomain)) {
       setError('Email domain does not match the Company Domain Name.');
       return;
     }
@@ -197,7 +202,7 @@ const SignupForm: React.FC<SignupFormProps> = ({ onSubmit }) => {
 
     // Company Duplicate checks
     const companyDupe = await isDuplicateCompany(companyName, fixedDomain);
-    if (companyDupe) {
+    if (!isNCentDomain(fixedEmail) && companyDupe) {
       setError('Company already exists in the system.  Please contact your company admin to create your login.');
       return;
     }


### PR DESCRIPTION
# Overview of changes

1.  Updated SignupForm component to detect when a user is trying to create an account with an @ncent.me email address
2. If they are an nCent user, relax validation rules so that we do not require the email domain to match the company domain and we do not check for company duplicates.

## Testing Steps

1. Navigate to the sign-up page for the brand portal
2. Create a new account using an email address ending with @ncent.me.   For example, you could try using "jacob.bailly+validationtest@ncent.me"
3. Enter company and domain information that does NOT match the ncent.me domain, and see if the system allows you to create a new account without validation errors.
